### PR TITLE
Implements group-based authorization

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,12 @@ $CONFIG = array (
     // Default group to add users to (optional, defaults to nothing)
     'oidc_login_default_group' => 'oidc',
 
+    // Authorize only the configured group to access Nextcloud. In case the user
+    // is not assigned to this group (read from oidc_login_attributes) the login
+    // will not be allowed for this user. When the user is not authorized, the user
+    // will neither be created nor its data updated.
+    'oidc_login_authorized_group' => 'admin',
+
     // Use external storage instead of a symlink to the home directory
     // Requires the files_external app to be enabled
     'oidc_login_use_external_storage' => false,


### PR DESCRIPTION
Support for group-based authroization is implemented in this commit. Only
the configured group defined in plugin configuration is able to access
Nextcloud. This authorized group is being read from optional
'oidc_login_authorized_group' configuration property.

In case the property is configured in plugin configuration and the user
is not assigned to the configured group, the login will not be allowed
for the user by failing the login process with an appropriate error
message. The user groups will be read from OIDC response using the
attribute configured in 'oidc_login_attributes' configuration property.
When the user is not authorized, the user will neither be created nor
its data will be updated in Nextcloud.

Fixes #69